### PR TITLE
Add an empty description for plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.2",
   "repository": "https://github.com/FliiFe/cerebro-giac.git",
   "author": "Théophile Cailliau (FliiFe)",
+  "description": "", 
   "license": "MIT",
   "dependencies": {
     "cerebro-tools": "^0.1.8",


### PR DESCRIPTION
Cerebro uses plugin description to show preview in plugins management. Since it is empty it was broken because Cerebro tried to call `description.replace(...)` for `undefined` (Fixing https://github.com/KELiON/cerebro/issues/459#issuecomment-387555927)

It will be fixed in new version of Cerebro but would be nice to fix for all users with this fix